### PR TITLE
Separate types for authzen apis

### DIFF
--- a/draft-brossard-oauth-rar-authzen.md
+++ b/draft-brossard-oauth-rar-authzen.md
@@ -203,20 +203,20 @@ Note: the aforementioned is indicative only. Always refer to [AUTHZEN] for the f
 Because **type** is **REQUIRED**, the new _authorization\_details_ structure is as follows:
 
 - type:
-An identifier for the authorization details type as a string. The value for this profile is "authzen". The value is case-insensitive. This field is **REQUIRED**.
+An identifier for the authorization details type as a string. The value for this profile is "authzen_evaluation" or "authzen_evaluations", corresponding to the AuthZEN API being invoked. The value is case-insensitive. This field is **REQUIRED**.
 
 - request:
 this field contains the entire AuthZEN-conformant authorization request. This field is **REQUIRED**.
 
 ## Authorization Details Types
 
-This profile declares a new value for the _type_ field as stated in the previous section. The value for this profile is "authzen". This indicates there will be a field called request and its value will be an AuthZEN-conformant authorization request.
+This profile declares a new value for the _type_ field as stated in the previous section. The value for this profile is "authzen_evaluation" or "authzen_evaluations". This indicates there will be another field called `request` and its value will be an AuthZEN-conformant authorization request.
 
 AuthZEN also defines a _type_ field in the Subject and Resource categories. This field is meant to describe the type of user and/or resource required.
 
 ## Common Data Fields
 
-No field other than `type` and `request` shall be allowed in `authorization_details` when the type is `authzen`. All other fields such as the ones mentioned in [RFC9396] shall be inserted inside the AuthZEN request in the relevant object (Subject, Resource, Action, or Context).
+No field other than `type` and `request` shall be allowed in `authorization_details` when the type is `authzen_evaluation` or `authzen_evaluations`. All other fields such as the ones mentioned in [RFC9396] shall be inserted inside the AuthZEN request in the relevant object (Subject, Resource, Action, or Context).
 
 # Authorization Request
 
@@ -233,7 +233,7 @@ Parameter encoding follows the exact same rules as [RFC9396].
 
 ~~~~language-json
 {
-  "type": "authzen",
+  "type": "authzen_evaluation",
   "request":
     {
         "subject": {
@@ -280,7 +280,7 @@ This example is based on the one in [RFC9396] under section 3.  Authorization Re
 ~~~~language-json
 [
   {
-    "type": "authzen",
+    "type": "authzen_evaluations",
     "request":
     {
       "subject": {
@@ -312,7 +312,7 @@ This example is based on the one in [RFC9396] under section 3.  Authorization Re
     }
   },
   {
-    "type": "authzen",
+    "type": "authzen_evaluations",
     "request":
     {
       "subject": {

--- a/draft-brossard-oauth-rar-authzen.md
+++ b/draft-brossard-oauth-rar-authzen.md
@@ -123,20 +123,21 @@ informative:
 
 --- abstract
 
-This specification defines a profile of OAuth 2.0 Rich Authorization Requests leveraging the OpenID AuthZEN authorization request/response formats within the authorization_details JSON object. Authorization servers and resource servers from different vendors can leverage this profile to request and receive relevant authorization decisions from an AuthZEN-compatible PDP in an interoperable manner.
+This specification defines a profile of OAuth 2.0 Rich Authorization Requests leveraging the OpenID AuthZEN authorization request/response formats within the `authorization_details` JSON object. Authorization servers and resource servers from different vendors can leverage this profile to request and receive relevant authorization decisions from an AuthZEN-compatible PDP in an interoperable manner.
 
 --- middle
 
 # Introduction
 
 OpenID AuthZEN is a Working Group under the OpenID Foundation which aims to increase interoperability and standardization in the authorization realm. In particular, AuthZEN aims to:
+
 - build standards-based authorization APIs
 - define standard design patterns for authorization
 - produce educational material to help raise awareness of externalized authorization.
 
-The aim of this profile is to define an AuthZEN-conformant profile of the OAuth 2.0 Rich Authorization Requests [RFC9396]. [RFC9396] introduces a new parameter authorization_details that allows clients to specify their fine-grained authorization requirements using the expressiveness of JSON [RFC8259] data structures.
+The aim of this profile is to define an AuthZEN-conformant profile of the OAuth 2.0 Rich Authorization Requests [RFC9396]. [RFC9396] introduces a new parameter `authorization_details` that allows clients to specify their fine-grained authorization requirements using the expressiveness of JSON [RFC8259] data structures.
 
-This specification introduces a more structured format for the authorization_details parameter. The new format is also JSON [RFC8259] as a result of which this specification is conformant with [RFC9396] and is merely a stricter profile.
+This specification introduces a more structured format for the `authorization_details` parameter. The new format is also JSON [RFC8259] as a result of which this specification is conformant with [RFC9396] and is merely a stricter profile.
 
 For example the authorization request for a credit transfer mentioned in [RFC9396] would now be structured as follows
 
@@ -171,7 +172,7 @@ For example the authorization request for a credit transfer mentioned in [RFC939
 ~~~~
 {: title='Source Authorization Request' sourcecode-markers="false"}
 
-Using AuthZEN as a format for authorization_details will increase the usability and the interoperability of [RFC9396]. In particular, it will be possible for the AS to forward the contents of the authorization_details parameter to an AuthZEN-conformant Policy Decision Point (PDP).
+Using AuthZEN as a format for `authorization_details` will increase the usability and the interoperability of [RFC9396]. In particular, it will be possible for the AS to forward the contents of the `authorization_details` parameter to an AuthZEN-conformant Policy Decision Point (PDP).
 
 # Conventions and Definitions
 
@@ -180,15 +181,16 @@ Using AuthZEN as a format for authorization_details will increase the usability 
 This specification uses the terms "access token", "refresh token", "authorization server" (AS), "resource server" (RS), "authorization endpoint", "authorization request", "authorization response", "token endpoint", "grant type", "access token request", "access token response", and "client" defined by "The OAuth 2.0 Authorization Framework" [RFC6749].
 This specification uses the terms "PDP" and "PEP" defined by [ABAC] and [XACML].
 
-# Request Parameter "authorization_details"
+# Request Parameter `authorization_details`
 
-In [RFC9396], the request parameter authorization_details contains, in JSON
+In [RFC9396], the request parameter `authorization_details` contains, in JSON
 notation, an array of objects.  Each JSON object contains the data to
 specify the authorization requirements for a certain type of
 resource. This specification defines the format for each one of these objects
 such that it conforms to [AUTHZEN] and [RFC9396].
 
 [AUTHZEN] groups JSON datastructures into 4 JSON objects:
+
 - subject: A Subject is the user or robotic principal about whom the Authorization API is being invoked. The Subject may be requesting access at the time the Authorization API is invoked.
 - resource: A Resource is the target of an access request. It is a JSON ([RFC8259]) object that is constructed similar to a Subject entity.
 - action: An Action is the type of access that the requester intends to perform. Action is a JSON ([RFC8259]) object that contains at least a name field.
@@ -196,7 +198,7 @@ such that it conforms to [AUTHZEN] and [RFC9396].
 
 Note: the aforementioned is indicative only. Always refer to [AUTHZEN] for the formal definition of each element.
 
-## "authorization_details" Structure
+## `authorization_details` Structure
 
 Because **type** is **REQUIRED**, the new _authorization\_details_ structure is as follows:
 
@@ -214,11 +216,11 @@ AuthZEN also defines a _type_ field in the Subject and Resource categories. This
 
 ## Common Data Fields
 
-No field other than type and authzen shall be allowed in authorization_details when the type is "authzen". All other fields such as the ones mentioned in [RFC9396] shall be inserted inside the AuthZEN request in the relevant object (Subject, Resource, Action, or Context).
+No field other than `type` and `request` shall be allowed in `authorization_details` when the type is `authzen`. All other fields such as the ones mentioned in [RFC9396] shall be inserted inside the AuthZEN request in the relevant object (Subject, Resource, Action, or Context).
 
 # Authorization Request
 
-Conformant to [RFC9396], the authorization_details authorization request parameter can be used to specify authorization requirements in all places where the scope parameter is used for the same purpose, examples include:
+Conformant to [RFC9396], the `authorization_details` authorization request parameter can be used to specify authorization requirements in all places where the scope parameter is used for the same purpose, examples include:
 
 - authorization requests as specified in [RFC6749]
 - device authorization requests as specified in [RFC8628]


### PR DESCRIPTION
This PR proposes having two different values for `authorization_details.type`:
- `authzen_evaluation`
- `authzen_evaluations`

This would allow a processor to easily call the correct API for the `request` payload that is passed in as part of the context. 

It would also set us up to introduce additional types, such as `authzen_subject_search` when we have search APIs defined.
